### PR TITLE
Mark this library as obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,3 @@
-## Documentation
+## This library is obsolete
 
-Please refer to the [documentation web page](https://dependency-injection-py.readthedocs.org/).
-
-## Running the tests
- 
-`tox` has to be installed in order to run the tests:
-
-    pip install tox
-    
-To run the tests:
-
-    tox
-
-If you don't have all the needed Python interpreters installed on your system
-but a Docker client available, here you go:
-
-    ./run-tests-with-docker
-
-You can also pass arguments to `tox`, e.g.:
- 
-    ./run-tests-with-docker -e py26
+You should use the standard [`inspect.signature()` function](https://docs.python.org/3/library/inspect.html#introspecting-callables-with-the-signature-object) introduced in Python 3.3 instead.

--- a/dependency_injection.py
+++ b/dependency_injection.py
@@ -1,6 +1,10 @@
 """This Python library defines a helper for building a dependency injection
 framework.
 
+.. warning:: This library is obsolete, you should use the standard `inspect.signature() function`_ introduced in Python 3.3 instead.
+
+.. _inspect.signature() function: https://docs.python.org/3/library/inspect.html#introspecting-callables-with-the-signature-object
+
 
 Installation
 ------------
@@ -49,9 +53,16 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 from collections import namedtuple
+import warnings
 
 
-__version__ = '1.2.0-dev'
+warnings.warn(DeprecationWarning(
+    "This module is obsolete, you should use the standard `inspect.signature()` "
+    "function introduced in Python 3.3 instead."
+))
+
+
+__version__ = '1.2.1'
 
 CLASSY_TYPES = (type(object),)
 if sys.version_info < (3,):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ copyright = u'Gittip, LLC'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = '1.2.0-dev'
+release = '1.2.1'
 # The short X.Y version.
 version = release.split('-', 1)[0]
 

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from setuptools import setup
 setup(name='dependency_injection',
       author='Chad Whitacre et al.',
       author_email='team@aspen.io',
-      description='This library defines a helper for building a dependency injection framework.',
+      description='This library is obsolete.',
       url='https://dependency-injection-py.readthedocs.org/',
-      version='1.2.0-dev',
+      version='1.2.1',
       py_modules=['dependency_injection'],
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I don't see any reason to keep maintaining this project, the [inspect.signature() function](https://docs.python.org/3/library/inspect.html#introspecting-callables-with-the-signature-object) available in the standard library since Python 3.3 is much better.